### PR TITLE
Support for CAP_DELAY

### DIFF
--- a/csrc/com/xuggle/xuggler/IStreamCoder.h
+++ b/csrc/com/xuggle/xuggler/IStreamCoder.h
@@ -481,6 +481,11 @@ namespace com { namespace xuggle { namespace xuggler
      * this method will reallocate the underlying buffers to
      * make them at least 192kbytes.
      * </p>
+     *
+     * Also, when done in order to flush the decoder, caller should call
+     * this method passing in 0 (null) for packet to tell the decoder
+     * to flush any data it was keeping a hold of.
+     *
      * @param pOutSamples The AudioSamples we decode to
      * @param packet    The packet we're attempting to decode from.
      * @param byteOffset Where in the packet payload to start decoding

--- a/csrc/com/xuggle/xuggler/IStreamCoder.h
+++ b/csrc/com/xuggle/xuggler/IStreamCoder.h
@@ -504,6 +504,10 @@ namespace com { namespace xuggle { namespace xuggler
      * you should pass the same IVideoPicture into this function
      * repeatedly until IVideoPicture::isComplete() is true.
      *
+     * Also, when done in order to flush the decoder, caller should call
+     * this method passing in 0 (null) for packet to tell the decoder
+     * to flush any data it was keeping a hold of.
+     *
      * @param pOutFrame The AudioSamples we decode.
      * @param packet    The packet we're attempting to decode from.
      * @param byteOffset Where in the packet payload to start decoding

--- a/csrc/com/xuggle/xuggler/StreamCoder.cpp
+++ b/csrc/com/xuggle/xuggler/StreamCoder.cpp
@@ -939,6 +939,9 @@ StreamCoder::decodeAudio(IAudioSamples *pOutSamples, IPacket *pPacket,
         avcodec_get_frame_defaults(&frame);
 
         retval = avcodec_decode_audio4(mCodecContext, &frame, &got_frame, &pkt);
+
+        if (!got_frame) outBufSize = 0;
+        
         // the API for decoding audio changed ot support planar audio and we
         // need to back-port
         if (retval >= 0 && got_frame) {


### PR DESCRIPTION
This adds support for flushing audio and video decoders by passing null packet. It also handles correctly case when audio decoder does not return any samples (also caused by CAP_DELAY).
