### PR TITLE
Fixes #6 - build now completes on OS X 10.8

### DIFF
--- a/captive/libvpx/csrc/build/make/gen_asm_deps.sh
+++ b/captive/libvpx/csrc/build/make/gen_asm_deps.sh
@@ -42,7 +42,7 @@ done
 
 [ -n "$srcfile" ] || show_help
 sfx=${sfx:-asm}
-includes=$(LC_ALL=C egrep -i "include +\"?+[a-z0-9_/]+\.${sfx}" $srcfile |
+includes=$(LC_ALL=C egrep -i "include +\"+[a-z0-9_/]+\.${sfx}" $srcfile |
            perl -p -e "s;.*?([a-z0-9_/]+.${sfx}).*;\1;")
 #" restore editor state
 for inc in ${includes}; do


### PR DESCRIPTION
Pulled in the changes from the homebrew [issue](https://github.com/mxcl/homebrew/issues/12567#issuecomment-6434000) with compiling libvpx.

Tested on OS X 10.8

``` bash
sudo ln -s /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer /Developer
export XUGGLE_HOME=/usr/local/xuggler
export PATH=$XUGGLE_HOME/bin:$PATH
export DYLD_LIBRARY_PATH=$XUGGLE_HOME/lib:$DYLD_LIBRARY_PATH
ant run-tests
```
