### PR TITLE
Cleans up some cruft.

### DIFF
--- a/src/com/xuggle/mediatool/MediaGeneratorAdapter.java
+++ b/src/com/xuggle/mediatool/MediaGeneratorAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2010 Xuggle Inc.  All rights reserved.
- *  
+ *
  * This file is part of Xuggle-Xuggler-Main.
  *
  * Xuggle-Xuggler-Main is free software: you can redistribute it and/or modify
@@ -33,10 +33,10 @@ import java.util.Collection;
  * {@link IMediaGenerator}, but want someone to declare support for it, and
  * implement the interface.
  * </p>
- * 
+ *
  * @author trebor
  * @author aclarke
- * 
+ *
  */
 public class MediaGeneratorAdapter extends AMediaGeneratorMixin implements
     IMediaGenerator
@@ -60,7 +60,6 @@ public class MediaGeneratorAdapter extends AMediaGeneratorMixin implements
    */
   public boolean addListener(IMediaListener listener)
   {
-    do {} while(false);
     return super.addListener(listener);
   }
 
@@ -69,7 +68,6 @@ public class MediaGeneratorAdapter extends AMediaGeneratorMixin implements
    */
   public Collection<IMediaListener> getListeners()
   {
-    do {} while(false);
     return super.getListeners();
   }
 
@@ -78,7 +76,6 @@ public class MediaGeneratorAdapter extends AMediaGeneratorMixin implements
    */
   public boolean removeListener(IMediaListener listener)
   {
-    do {} while(false);
     return super.removeListener(listener);
   }
 

--- a/src/com/xuggle/mediatool/MediaListenerAdapter.java
+++ b/src/com/xuggle/mediatool/MediaListenerAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2010 Xuggle Inc.  All rights reserved.
- *  
+ *
  * This file is part of Xuggle-Xuggler-Main.
  *
  * Xuggle-Xuggler-Main is free software: you can redistribute it and/or modify
@@ -35,15 +35,15 @@ import com.xuggle.mediatool.event.IWriteTrailerEvent;
 
 
 /**
- * An implementation of {@link IMediaListener} that 
+ * An implementation of {@link IMediaListener} that
  * implements all methods as empty methods.
- * 
+ *
  * <p>
- * 
+ *
  * This can be useful if you only want to override some members of
  * {@link IMediaListener}; instead, just subclass this and override the methods
  * you want, rather than providing an implementation of all methods.
- * 
+ *
  * </p>
  */
 
@@ -57,12 +57,11 @@ extends AMediaListenerMixin implements IMediaListener
   {
     super();
   }
-  
+
   /** {@inheritDoc} */
 
   public void onVideoPicture(IVideoPictureEvent event)
   {
-    do {} while(false);
     super.onVideoPicture(event);
   }
 
@@ -70,7 +69,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onAudioSamples(IAudioSamplesEvent event)
   {
-    do {} while(false);
     super.onAudioSamples(event);
   }
 
@@ -78,7 +76,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onOpen(IOpenEvent event)
   {
-    do {} while(false);
     super.onOpen(event);
   }
 
@@ -86,7 +83,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onClose(ICloseEvent event)
   {
-    do {} while(false);
     super.onClose(event);
   }
 
@@ -94,7 +90,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onAddStream(IAddStreamEvent event)
   {
-    do {} while(false);
     super.onAddStream(event);
   }
 
@@ -102,7 +97,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onOpenCoder(IOpenCoderEvent event)
   {
-    do {} while(false);
     super.onOpenCoder(event);
   }
 
@@ -110,7 +104,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onCloseCoder(ICloseCoderEvent event)
   {
-    do {} while(false);
     super.onCloseCoder(event);
   }
 
@@ -118,7 +111,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onReadPacket(IReadPacketEvent event)
   {
-    do {} while(false);
     super.onReadPacket(event);
   }
 
@@ -126,7 +118,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onWritePacket(IWritePacketEvent event)
   {
-    do {} while(false);
     super.onWritePacket(event);
   }
 
@@ -134,7 +125,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onWriteHeader(IWriteHeaderEvent event)
   {
-    do {} while(false);
     super.onWriteHeader(event);
   }
 
@@ -142,7 +132,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onFlush(IFlushEvent event)
   {
-    do {} while(false);
     super.onFlush(event);
   }
 
@@ -150,7 +139,6 @@ extends AMediaListenerMixin implements IMediaListener
 
   public void onWriteTrailer(IWriteTrailerEvent event)
   {
-    do {} while(false);
     super.onWriteTrailer(event);
   }
 }

--- a/src/com/xuggle/mediatool/MediaToolAdapter.java
+++ b/src/com/xuggle/mediatool/MediaToolAdapter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2010 Xuggle Inc.  All rights reserved.
- *  
+ *
  * This file is part of Xuggle-Xuggler-Main.
  *
  * Xuggle-Xuggler-Main is free software: you can redistribute it and/or modify
@@ -38,12 +38,12 @@ import com.xuggle.mediatool.event.IWriteTrailerEvent;
  * forwards all {@link IMediaListener} events to
  * listeners registered with {@link #addListener(IMediaListener)}.
  * <p>
- * Forwards every call on the {@link IMediaListener} interface methods to all 
+ * Forwards every call on the {@link IMediaListener} interface methods to all
  * listeners added on the {@link IMediaGenerator} interface, and
  * declares its support of the {@link IMediaTool} interface.
  * </p>
  * <p>
- * This can be useful if you want to implement your own 
+ * This can be useful if you want to implement your own
  * {@link IMediaTool}, want help implementing the
  * {@link IMediaListener} call backs, and want your parent
  * class to declare support for the {@link IMediaTool} interface.
@@ -66,7 +66,6 @@ implements IMediaTool
    */
   public boolean addListener(IMediaListener listener)
   {
-    do {} while(false);
     return super.addListener(listener);
   }
 
@@ -75,7 +74,6 @@ implements IMediaTool
    */
   public Collection<IMediaListener> getListeners()
   {
-    do {} while(false);
     return super.getListeners();
   }
 
@@ -84,7 +82,6 @@ implements IMediaTool
    */
   public boolean removeListener(IMediaListener listener)
   {
-    do {} while(false);
     return super.removeListener(listener);
   }
 
@@ -93,7 +90,6 @@ implements IMediaTool
    */
   public void onAddStream(IAddStreamEvent event)
   {
-    do {} while(false);
     super.onAddStream(event);
   }
 
@@ -102,7 +98,6 @@ implements IMediaTool
    */
   public void onAudioSamples(IAudioSamplesEvent event)
   {
-    do {} while(false);
     super.onAudioSamples(event);
   }
 
@@ -111,7 +106,6 @@ implements IMediaTool
    */
   public void onClose(ICloseEvent event)
   {
-    do {} while(false);
     super.onClose(event);
   }
 
@@ -120,7 +114,6 @@ implements IMediaTool
    */
   public void onCloseCoder(ICloseCoderEvent event)
   {
-    do {} while(false);
     super.onCloseCoder(event);
   }
 
@@ -129,7 +122,6 @@ implements IMediaTool
    */
   public void onFlush(IFlushEvent event)
   {
-    do {} while(false);
     super.onFlush(event);
   }
 
@@ -138,7 +130,6 @@ implements IMediaTool
    */
   public void onOpen(IOpenEvent event)
   {
-    do {} while(false);
     super.onOpen(event);
   }
 
@@ -147,7 +138,6 @@ implements IMediaTool
    */
   public void onOpenCoder(IOpenCoderEvent event)
   {
-    do {} while(false);
     super.onOpenCoder(event);
   }
 
@@ -156,8 +146,7 @@ implements IMediaTool
    */
   public void onReadPacket(IReadPacketEvent event)
   {
-    do {} while(false);
-    super.onReadPacket(event); 
+    super.onReadPacket(event);
   }
 
   /**
@@ -165,7 +154,6 @@ implements IMediaTool
    */
   public void onVideoPicture(IVideoPictureEvent event)
   {
-    do {} while(false);
     super.onVideoPicture(event);
   }
 
@@ -174,7 +162,6 @@ implements IMediaTool
    */
   public void onWriteHeader(IWriteHeaderEvent event)
   {
-    do {} while(false);
     super.onWriteHeader(event);
   }
 
@@ -183,8 +170,7 @@ implements IMediaTool
    */
   public void onWritePacket(IWritePacketEvent event)
   {
-    do {} while(false);
-    super.onWritePacket(event); 
+    super.onWritePacket(event);
   }
 
   /**
@@ -192,7 +178,6 @@ implements IMediaTool
    */
   public void onWriteTrailer(IWriteTrailerEvent event)
   {
-    do {} while(false);
     super.onWriteTrailer(event);
   }
 

--- a/src/com/xuggle/xuggler/demos/DecodeAndPlayAudioAndVideo.java
+++ b/src/com/xuggle/xuggler/demos/DecodeAndPlayAudioAndVideo.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2010 Xuggle Inc.  All rights reserved.
- *  
+ *
  * This file is part of Xuggle-Xuggler-Main.
  *
  * Xuggle-Xuggler-Main is free software: you can redistribute it and/or modify
@@ -45,7 +45,7 @@ import com.xuggle.xuggler.Utils;
  * the audio and video will float in and out of slight sync.  Getting
  * time-stamps syncing-up with audio is very system dependent and left
  * as an exercise for the reader.
- * 
+ *
  * @author aclarke
  *
  */
@@ -59,19 +59,19 @@ public class DecodeAndPlayAudioAndVideo
 
   /**
    * The window we'll draw the video on.
-   * 
+   *
    */
   private static VideoImage mScreen = null;
 
   private static long mSystemVideoClockStartTime;
 
   private static long mFirstVideoTimestampInStream;
-  
+
   /**
    * Takes a media container (file) as the first argument, opens it,
    * plays audio as quickly as it can, and opens up a Swing window and displays
    * video frames with <i>roughly</i> the right timing.
-   *  
+   *
    * @param args Must contain one string which represents a filename
    */
   @SuppressWarnings("deprecation")
@@ -79,23 +79,23 @@ public class DecodeAndPlayAudioAndVideo
   {
     if (args.length <= 0)
       throw new IllegalArgumentException("must pass in a filename as the first argument");
-    
+
     String filename = args[0];
-    
+
     // Let's make sure that we can actually convert video pixel formats.
     if (!IVideoResampler.isSupported(IVideoResampler.Feature.FEATURE_COLORSPACECONVERSION))
       throw new RuntimeException("you must install the GPL version of Xuggler (with IVideoResampler support) for this demo to work");
-    
+
     // Create a Xuggler container object
     IContainer container = IContainer.make();
-    
+
     // Open up the container
     if (container.open(filename, IContainer.Type.READ, null) < 0)
       throw new IllegalArgumentException("could not open file: " + filename);
-    
+
     // query how many streams the call to open found
     int numStreams = container.getNumStreams();
-    
+
     // and iterate through the streams to find the first audio stream
     int videoStreamId = -1;
     IStreamCoder videoCoder = null;
@@ -107,7 +107,7 @@ public class DecodeAndPlayAudioAndVideo
       IStream stream = container.getStream(i);
       // Get the pre-configured decoder that can decode this stream;
       IStreamCoder coder = stream.getStreamCoder();
-      
+
       if (videoStreamId == -1 && coder.getCodecType() == ICodec.Type.CODEC_TYPE_VIDEO)
       {
         videoStreamId = i;
@@ -121,7 +121,7 @@ public class DecodeAndPlayAudioAndVideo
     }
     if (videoStreamId == -1 && audioStreamId == -1)
       throw new RuntimeException("could not find audio or video stream in container: "+filename);
-    
+
     /*
      * Check if we have a video stream in this file.  If so let's open up our decoder so it can
      * do work.
@@ -131,7 +131,7 @@ public class DecodeAndPlayAudioAndVideo
     {
       if(videoCoder.open() < 0)
         throw new RuntimeException("could not open audio decoder for container: "+filename);
-    
+
       if (videoCoder.getPixelType() != IPixelFormat.Type.BGR24)
       {
         // if this stream is not in BGR24, we're going to need to
@@ -146,12 +146,12 @@ public class DecodeAndPlayAudioAndVideo
        */
       openJavaVideo();
     }
-    
+
     if (audioCoder != null)
     {
       if (audioCoder.open() < 0)
         throw new RuntimeException("could not open audio decoder for container: "+filename);
-      
+
       /*
        * And once we have that, we ask the Java Sound System to get itself ready.
        */
@@ -164,8 +164,8 @@ public class DecodeAndPlayAudioAndVideo
         throw new RuntimeException("unable to open sound device on your system when playing back container: "+filename);
       }
     }
-    
-    
+
+
     /*
      * Now, we start walking through the container looking at each packet.
      */
@@ -184,10 +184,10 @@ public class DecodeAndPlayAudioAndVideo
          */
         IVideoPicture picture = IVideoPicture.make(videoCoder.getPixelType(),
             videoCoder.getWidth(), videoCoder.getHeight());
-        
+
         /*
          * Now, we decode the video, checking for any errors.
-         * 
+         *
          */
         int bytesDecoded = videoCoder.decodeVideo(picture, packet, 0);
         if (bytesDecoded < 0)
@@ -238,19 +238,19 @@ public class DecodeAndPlayAudioAndVideo
         /*
          * We allocate a set of samples with the same number of channels as the
          * coder tells us is in this buffer.
-         * 
+         *
          * We also pass in a buffer size (1024 in our example), although Xuggler
          * will probably allocate more space than just the 1024 (it's not important why).
          */
         IAudioSamples samples = IAudioSamples.make(1024, audioCoder.getChannels());
-        
+
         /*
          * A packet can actually contain multiple sets of samples (or frames of samples
          * in audio-decoding speak).  So, we may need to call decode audio multiple
          * times at different offsets in the packet's data.  We capture that here.
          */
         int offset = 0;
-        
+
         /*
          * Keep going until we've processed all data
          */
@@ -279,12 +279,12 @@ public class DecodeAndPlayAudioAndVideo
         /*
          * This packet isn't part of our video stream, so we just silently drop it.
          */
-        do {} while(false);
+        continue;
       }
-      
+
     }
     /*
-     * Technically since we're exiting anyway, these will be cleaned up by 
+     * Technically since we're exiting anyway, these will be cleaned up by
      * the garbage collector... but because we're nice people and want
      * to be invited places for Christmas, we're going to show how to clean up.
      */
@@ -298,11 +298,9 @@ public class DecodeAndPlayAudioAndVideo
       audioCoder.close();
       audioCoder = null;
     }
-    if (container !=null)
-    {
-      container.close();
-      container = null;
-    }
+    container.close();
+    container = null;
+
     closeJavaSound();
     closeJavaVideo();
   }
@@ -312,11 +310,11 @@ public class DecodeAndPlayAudioAndVideo
     /**
      * We could just display the images as quickly as we decode them, but it turns
      * out we can decode a lot faster than you think.
-     * 
+     *
      * So instead, the following code does a poor-man's version of trying to
      * match up the frame-rate requested for each IVideoPicture with the system
      * clock time on your computer.
-     * 
+     *
      * Remember that all Xuggler IAudioSamples and IVideoPicture objects always
      * give timestamps in Microseconds, relative to the first decoded item.  If
      * instead you used the packet timestamps, they can be in different units depending
@@ -379,8 +377,8 @@ public class DecodeAndPlayAudioAndVideo
      * And if that succeed, start the line.
      */
     mLine.start();
-    
-    
+
+
   }
 
   private static void playJavaSound(IAudioSamples aSamples)

--- a/src/com/xuggle/xuggler/demos/DecodeAndPlayVideo.java
+++ b/src/com/xuggle/xuggler/demos/DecodeAndPlayVideo.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2010 Xuggle Inc.  All rights reserved.
- *  
+ *
  * This file is part of Xuggle-Xuggler-Main.
  *
  * Xuggle-Xuggler-Main is free software: you can redistribute it and/or modify
@@ -35,7 +35,7 @@ import com.xuggle.xuggler.Utils;
 /**
  * Takes a media container, finds the first video stream,
  * decodes that stream, and then displays the video frames,
- * at the frame-rate specified by the container, on a 
+ * at the frame-rate specified by the container, on a
  * window.
  * @author aclarke
  *
@@ -47,7 +47,7 @@ public class DecodeAndPlayVideo
    * Takes a media container (file) as the first argument, opens it,
    * opens up a Swing window and displays
    * video frames with <i>roughly</i> the right timing.
-   *  
+   *
    * @param args Must contain one string which represents a filename
    */
   @SuppressWarnings("deprecation")
@@ -110,7 +110,7 @@ public class DecodeAndPlayVideo
     {
       // if this stream is not in BGR24, we're going to need to
       // convert it.  The VideoResampler does that for us.
-      resampler = IVideoResampler.make(videoCoder.getWidth(), 
+      resampler = IVideoResampler.make(videoCoder.getWidth(),
           videoCoder.getHeight(), IPixelFormat.Type.BGR24,
           videoCoder.getWidth(), videoCoder.getHeight(), videoCoder.getPixelType());
       if (resampler == null)
@@ -133,145 +133,137 @@ public class DecodeAndPlayVideo
       /*
        * Now we have a packet, let's see if it belongs to our video stream
        */
-      if (packet.getStreamIndex() == videoStreamId)
-      {
-        /*
-         * We allocate a new picture to get the data out of Xuggler
-         */
-        IVideoPicture picture = IVideoPicture.make(videoCoder.getPixelType(),
-            videoCoder.getWidth(), videoCoder.getHeight());
-
-        int offset = 0;
-        while(offset < packet.getSize())
-        {
-          /*
-           * Now, we decode the video, checking for any errors.
-           * 
-           */
-          int bytesDecoded = videoCoder.decodeVideo(picture, packet, offset);
-          if (bytesDecoded < 0)
-            throw new RuntimeException("got error decoding video in: "
-                + filename);
-          offset += bytesDecoded;
-
-          /*
-           * Some decoders will consume data in a packet, but will not be able to construct
-           * a full video picture yet.  Therefore you should always check if you
-           * got a complete picture from the decoder
-           */
-          if (picture.isComplete())
-          {
-            IVideoPicture newPic = picture;
-            /*
-             * If the resampler is not null, that means we didn't get the
-             * video in BGR24 format and
-             * need to convert it into BGR24 format.
-             */
-            if (resampler != null)
-            {
-              // we must resample
-              newPic = IVideoPicture.make(resampler.getOutputPixelFormat(),
-                  picture.getWidth(), picture.getHeight());
-              if (resampler.resample(newPic, picture) < 0)
-                throw new RuntimeException("could not resample video from: "
-                    + filename);
-            }
-            if (newPic.getPixelType() != IPixelFormat.Type.BGR24)
-              throw new RuntimeException("could not decode video" +
-              		" as BGR 24 bit data in: " + filename);
-
-            /**
-             * We could just display the images as quickly as we decode them,
-             * but it turns out we can decode a lot faster than you think.
-             * 
-             * So instead, the following code does a poor-man's version of
-             * trying to match up the frame-rate requested for each
-             * IVideoPicture with the system clock time on your computer.
-             * 
-             * Remember that all Xuggler IAudioSamples and IVideoPicture objects
-             * always give timestamps in Microseconds, relative to the first
-             * decoded item. If instead you used the packet timestamps, they can
-             * be in different units depending on your IContainer, and IStream
-             * and things can get hairy quickly.
-             */
-            if (firstTimestampInStream == Global.NO_PTS)
-            {
-              // This is our first time through
-              firstTimestampInStream = picture.getTimeStamp();
-              // get the starting clock time so we can hold up frames
-              // until the right time.
-              systemClockStartTime = System.currentTimeMillis();
-            } else {
-              long systemClockCurrentTime = System.currentTimeMillis();
-              long millisecondsClockTimeSinceStartofVideo =
-                systemClockCurrentTime - systemClockStartTime;
-              // compute how long for this frame since the first frame in the
-              // stream.
-              // remember that IVideoPicture and IAudioSamples timestamps are
-              // always in MICROSECONDS,
-              // so we divide by 1000 to get milliseconds.
-              long millisecondsStreamTimeSinceStartOfVideo =
-                (picture.getTimeStamp() - firstTimestampInStream)/1000;
-              final long millisecondsTolerance = 50; // and we give ourselfs 50 ms of tolerance
-              final long millisecondsToSleep = 
-                (millisecondsStreamTimeSinceStartOfVideo -
-                  (millisecondsClockTimeSinceStartofVideo +
-                      millisecondsTolerance));
-              if (millisecondsToSleep > 0)
-              {
-                try
-                {
-                  Thread.sleep(millisecondsToSleep);
-                }
-                catch (InterruptedException e)
-                {
-                  // we might get this when the user closes the dialog box, so
-                  // just return from the method.
-                  return;
-                }
-              }
-            }
-
-            // And finally, convert the BGR24 to an Java buffered image
-            BufferedImage javaImage = Utils.videoPictureToImage(newPic);
-
-            // and display it on the Java Swing window
-            updateJavaWindow(javaImage);
-          }
-        }
-      }
-      else
+      if (packet.getStreamIndex() != videoStreamId)
       {
         /*
          * This packet isn't part of our video stream, so we just
          * silently drop it.
          */
-        do {} while(false);
+        continue;
       }
 
+      /*
+       * We allocate a new picture to get the data out of Xuggler
+       */
+      IVideoPicture picture = IVideoPicture.make(videoCoder.getPixelType(),
+          videoCoder.getWidth(), videoCoder.getHeight());
+
+      int offset = 0;
+      while(offset < packet.getSize())
+      {
+        /*
+         * Now, we decode the video, checking for any errors.
+         *
+         */
+        int bytesDecoded = videoCoder.decodeVideo(picture, packet, offset);
+        if (bytesDecoded < 0)
+          throw new RuntimeException("got error decoding video in: "
+              + filename);
+        offset += bytesDecoded;
+
+        /*
+         * Some decoders will consume data in a packet, but will not be able to construct
+         * a full video picture yet.  Therefore you should always check if you
+         * got a complete picture from the decoder
+         */
+        if (picture.isComplete())
+        {
+          IVideoPicture newPic = picture;
+          /*
+           * If the resampler is not null, that means we didn't get the
+           * video in BGR24 format and
+           * need to convert it into BGR24 format.
+           */
+          if (resampler != null)
+          {
+            // we must resample
+            newPic = IVideoPicture.make(resampler.getOutputPixelFormat(),
+                picture.getWidth(), picture.getHeight());
+            if (resampler.resample(newPic, picture) < 0)
+              throw new RuntimeException("could not resample video from: "
+                  + filename);
+          }
+          if (newPic.getPixelType() != IPixelFormat.Type.BGR24)
+            throw new RuntimeException("could not decode video" +
+            		" as BGR 24 bit data in: " + filename);
+
+          /**
+           * We could just display the images as quickly as we decode them,
+           * but it turns out we can decode a lot faster than you think.
+           *
+           * So instead, the following code does a poor-man's version of
+           * trying to match up the frame-rate requested for each
+           * IVideoPicture with the system clock time on your computer.
+           *
+           * Remember that all Xuggler IAudioSamples and IVideoPicture objects
+           * always give timestamps in Microseconds, relative to the first
+           * decoded item. If instead you used the packet timestamps, they can
+           * be in different units depending on your IContainer, and IStream
+           * and things can get hairy quickly.
+           */
+          if (firstTimestampInStream == Global.NO_PTS)
+          {
+            // This is our first time through
+            firstTimestampInStream = picture.getTimeStamp();
+            // get the starting clock time so we can hold up frames
+            // until the right time.
+            systemClockStartTime = System.currentTimeMillis();
+          } else {
+            long systemClockCurrentTime = System.currentTimeMillis();
+            long millisecondsClockTimeSinceStartofVideo =
+              systemClockCurrentTime - systemClockStartTime;
+            // compute how long for this frame since the first frame in the
+            // stream.
+            // remember that IVideoPicture and IAudioSamples timestamps are
+            // always in MICROSECONDS,
+            // so we divide by 1000 to get milliseconds.
+            long millisecondsStreamTimeSinceStartOfVideo =
+              (picture.getTimeStamp() - firstTimestampInStream)/1000;
+            final long millisecondsTolerance = 50; // and we give ourselfs 50 ms of tolerance
+            final long millisecondsToSleep =
+              (millisecondsStreamTimeSinceStartOfVideo -
+                (millisecondsClockTimeSinceStartofVideo +
+                    millisecondsTolerance));
+            if (millisecondsToSleep > 0)
+            {
+              try
+              {
+                Thread.sleep(millisecondsToSleep);
+              }
+              catch (InterruptedException e)
+              {
+                // we might get this when the user closes the dialog box, so
+                // just return from the method.
+                return;
+              }
+            }
+          }
+
+          // And finally, convert the BGR24 to an Java buffered image
+          BufferedImage javaImage = Utils.videoPictureToImage(newPic);
+
+          // and display it on the Java Swing window
+          updateJavaWindow(javaImage);
+        }
+      }
     }
+
     /*
-     * Technically since we're exiting anyway, these will be cleaned up by 
+     * Technically since we're exiting anyway, these will be cleaned up by
      * the garbage collector... but because we're nice people and want
      * to be invited places for Christmas, we're going to show how to clean up.
      */
-    if (videoCoder != null)
-    {
-      videoCoder.close();
-      videoCoder = null;
-    }
-    if (container !=null)
-    {
-      container.close();
-      container = null;
-    }
-    closeJavaWindow();
+    videoCoder.close();
+    videoCoder = null;
+    container.close();
+    container = null;
 
+    closeJavaWindow();
   }
 
   /**
    * The window we'll draw the video on.
-   * 
+   *
    */
   private static VideoImage mScreen = null;
 


### PR DESCRIPTION
Unless I'm missing something, this just removes cruft.

The null checks in the demos are unnecessary, as we dereference the variables earlier in the functions. (H/t FindBugs.)

The instances of "do {} while(false);" seem to be totally unnecessary.
